### PR TITLE
Making command shortcuts shorter

### DIFF
--- a/Resources/config/redis.xml
+++ b/Resources/config/redis.xml
@@ -18,10 +18,12 @@
         </service>
         <service id="snc_redis.command.flush_all" class="Snc\RedisBundle\Command\RedisFlushallCommand" public="false">
             <tag name="console.command" command="redis:flushall" />
+            <tag name="console.command" command="redis:flush:all" />
             <tag name="snc_redis.command" />
         </service>
         <service id="snc_redis.command.flush_db" class="Snc\RedisBundle\Command\RedisFlushdbCommand" public="false">
             <tag name="console.command" command="redis:flushdb" />
+            <tag name="console.command" command="redis:flush:db" />
             <tag name="snc_redis.command" />
         </service>
     </services>


### PR DESCRIPTION
By splitting the flush commands names, you can use commands like bin/console r:f:a to flushall. I've preserved backwards compatibility by keeping the old names.